### PR TITLE
feat(react): Add support for jsx and tsx files

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -5,7 +5,7 @@ import { normalizePath } from '@rollup/pluginutils'
 const APP_ROOT_PATH = normalizePath(process.cwd())
 export const appRootPathRE = new RegExp(APP_ROOT_PATH, 'i')
 export const userJSFilePathRE = new RegExp(
-  APP_ROOT_PATH + '/(?!node_modules).*\\.[tj]s$',
+  APP_ROOT_PATH + '/(?!node_modules).*\\.[tj]s[x]?$',
   'i'
 )
 export const CHUNK_NAME_TAG = 'chunkName'


### PR DESCRIPTION
## Why

This plugin is great but when used in a non-vue project the regular expression will not pick the application source if the file extension is tsx or jsx.

## Changes
· Modify the [userJSFilePathRE](https://github.com/CaptainLiao/vite-plugin-webpackchunkname/blob/master/src/share.ts#L7) regexp to be able to recognise these file extensions.

## Screenshots

Before

![image](https://user-images.githubusercontent.com/14946058/165910532-b98704a1-9661-4f82-b017-4d0718e30c9c.png)


After

![image](https://user-images.githubusercontent.com/14946058/165910142-e94a2fed-0f6a-489b-a61e-40275e76f916.png)
